### PR TITLE
fix: Fix incorrect `text-wrap` property in CSS

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,6 @@
 
 @layer utilities {
   .text-balance {
-    text-wrap: balance;
+    word-wrap: break-word;
   }
 }


### PR DESCRIPTION
I noticed that the `text-wrap` property was used in the CSS code, but it doesn't exist. I've replaced it with the correct property: `word-wrap` (or `overflow-wrap`, depending on the context).
This ensures that text wrapping works properly and adheres to CSS standards.